### PR TITLE
fix: continue chain on missing auth

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -94,6 +94,10 @@ func jWTMiddleware(jwtPublicKeyLocation string, userDefinedConfig ...echojwt.Con
 		config = echojwt.Config{
 			// specify the function that returns the public key that will be used to verify the JWT
 			KeyFunc: fetchKey(jwtPublicKeyLocation),
+			Skipper: func(c echo.Context) bool {
+				header := c.Request().Header.Get("Authorization")
+				return header == ""
+			},
 		}
 	}
 	// Create a restricted group of routes that requires a valid JWT
@@ -106,7 +110,8 @@ func restricted() echo.MiddlewareFunc {
 			// Get the "user" from the context, the user is set by the JWT middleware and is a *jwt.Token
 			user := c.Get("user")
 			if user == nil {
-				return echo.ErrUnauthorized
+				// just continue
+				return next(c)
 			}
 			token := user.(*jwt.Token)
 

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -66,12 +66,11 @@ func TestRestricted(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	t.Run("should return an error if the user is not authenticated", func(t *testing.T) {
+	t.Run("should return if the user is not authenticated", func(t *testing.T) {
 		err := restricted()(func(c echo.Context) error {
 			return nil
 		})(c)
-		assert.Error(t, err)
-		assert.Equal(t, echo.ErrUnauthorized, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("should set a jwt token on the context if the user is authenticated", func(t *testing.T) {


### PR DESCRIPTION
When we don't have a JWT just continue down the chain of middlewares